### PR TITLE
[TKT-37] #17/feat/authInterceptor

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
@@ -14,6 +14,7 @@ import wisoft.io.quotation.application.port.`in`.GetUserUseCase
 import wisoft.io.quotation.application.port.`in`.DeleteUserUseCase
 import wisoft.io.quotation.application.port.`in`.SignInUseCase
 import wisoft.io.quotation.application.port.`in`.CreateUserUseCase
+import wisoft.io.quotation.util.annotation.Authenticated
 
 @RestController
 class UserController(
@@ -64,6 +65,7 @@ class UserController(
     }
 
     @DeleteMapping("/users/{id}")
+    @Authenticated
     fun deleteUser(@PathVariable("id") id: String): ResponseEntity<DeleteUserUseCase> {
         deleteUserUseCase.deleteUser(id)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/interceptor/AuthInterceptor.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/interceptor/AuthInterceptor.kt
@@ -6,7 +6,6 @@ import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.HandlerInterceptor
-import wisoft.io.quotation.exception.error.InvalidJwtTokenException
 import wisoft.io.quotation.exception.error.UnauthorizedUserException
 import wisoft.io.quotation.util.JWTUtil
 import wisoft.io.quotation.util.annotation.Authenticated
@@ -19,8 +18,10 @@ class AuthInterceptor : HandlerInterceptor {
         handler.getMethodAnnotation(Authenticated::class.java) ?: return true
 
         return runCatching {
-            val authToken = request.getHeader("Authorization") ?: throw UnauthorizedUserException("")
-            JWTUtil.verifyToken(authToken)
+            val authHeader = request.getHeader("Authorization") ?: throw UnauthorizedUserException("Authorization Not Found")
+            val token = authHeader.substringAfter("Bearer ")
+
+            JWTUtil.verifyToken(token)
         }.onFailure {
             logger.error { "preHandle fail" }
         }.getOrThrow()

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/interceptor/AuthInterceptor.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/interceptor/AuthInterceptor.kt
@@ -1,0 +1,28 @@
+package wisoft.io.quotation.adaptor.`in`.http.interceptor
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+import wisoft.io.quotation.exception.error.InvalidJwtTokenException
+import wisoft.io.quotation.exception.error.UnauthorizedUserException
+import wisoft.io.quotation.util.JWTUtil
+import wisoft.io.quotation.util.annotation.Authenticated
+
+@Component
+class AuthInterceptor : HandlerInterceptor {
+    val logger = KotlinLogging.logger {}
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        if (handler !is HandlerMethod) return true
+        handler.getMethodAnnotation(Authenticated::class.java) ?: return true
+
+        return runCatching {
+            val authToken = request.getHeader("Authorization") ?: throw UnauthorizedUserException("")
+            JWTUtil.verifyToken(authToken)
+        }.onFailure {
+            logger.error { "preHandle fail" }
+        }.getOrThrow()
+    }
+}

--- a/src/main/kotlin/wisoft/io/quotation/config/WebConfig.kt
+++ b/src/main/kotlin/wisoft/io/quotation/config/WebConfig.kt
@@ -1,0 +1,13 @@
+package wisoft.io.quotation.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import wisoft.io.quotation.adaptor.`in`.http.interceptor.AuthInterceptor
+
+@Configuration
+class WebConfig: WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(AuthInterceptor())
+    }
+}

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/InvalidJwtTokenException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/InvalidJwtTokenException.kt
@@ -1,0 +1,5 @@
+package wisoft.io.quotation.exception.error
+
+import wisoft.io.quotation.exception.error.http.ForbiddenException
+
+class InvalidJwtTokenException (override val value: String): ForbiddenException(value = value)

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/UnauthorizedUserException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/UnauthorizedUserException.kt
@@ -1,0 +1,5 @@
+package wisoft.io.quotation.exception.error
+
+import wisoft.io.quotation.exception.error.http.UnauthorizedException
+
+class UnauthorizedUserException (override val value: String): UnauthorizedException(value = value)

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/http/ForbiddenException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/http/ForbiddenException.kt
@@ -1,0 +1,7 @@
+package wisoft.io.quotation.exception.error.http
+
+open class ForbiddenException(
+    open val value: String
+) : Throwable(
+    message = value + HttpMessage.HTTP_403
+)

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/http/HttpMessage.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/http/HttpMessage.kt
@@ -7,5 +7,7 @@ enum class HttpMessage(
     val message: String
 ) {
     HTTP_400(HttpStatus.BAD_REQUEST, " 잘못된 요청입니다."),
-    HTTP_404(HttpStatus.NOT_FOUND, " 리소스가 존재하지 않습니다.")
+    HTTP_401(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    HTTP_403(HttpStatus.FORBIDDEN, "사용자는콘텐츠에 접근할 권리를 가지고 있지 않습니다."),
+    HTTP_404(HttpStatus.NOT_FOUND, " 리소스가 존재하지 않습니다."),
 }

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/http/UnauthorizedException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/http/UnauthorizedException.kt
@@ -1,0 +1,7 @@
+package wisoft.io.quotation.exception.error.http
+
+open class UnauthorizedException(
+    open val value: String
+) : Throwable(
+    message = value + HttpMessage.HTTP_401
+)

--- a/src/main/kotlin/wisoft/io/quotation/exception/handler/ExceptionHandler.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/handler/ExceptionHandler.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import wisoft.io.quotation.exception.error.*
 import wisoft.io.quotation.exception.error.http.HttpMessage
+import wisoft.io.quotation.exception.error.http.UnauthorizedException
 
 @RestControllerAdvice
 class ExceptionHandler {
@@ -70,6 +71,32 @@ class ExceptionHandler {
         request: HttpServletRequest
     ): ResponseEntity<ErrorData> {
         val status = HttpMessage.HTTP_400.status
+        val errorMessage = ErrorData(ErrorMessage.from(status, e, request))
+
+        return ResponseEntity
+            .status(status)
+            .body(errorMessage)
+    }
+
+    @ExceptionHandler(UnauthorizedUserException::class)
+    fun unauthorizedUserExceptionHandler(
+        e: UnauthorizedUserException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorData> {
+        val status = HttpMessage.HTTP_401.status
+        val errorMessage = ErrorData(ErrorMessage.from(status, e, request))
+
+        return ResponseEntity
+            .status(status)
+            .body(errorMessage)
+    }
+
+    @ExceptionHandler(InvalidJwtTokenException::class)
+    fun invalidJwtTokenExceptionExceptionHandler(
+        e: InvalidJwtTokenException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorData> {
+        val status = HttpMessage.HTTP_403.status
         val errorMessage = ErrorData(ErrorMessage.from(status, e, request))
 
         return ResponseEntity

--- a/src/main/kotlin/wisoft/io/quotation/util/JWTUtil.kt
+++ b/src/main/kotlin/wisoft/io/quotation/util/JWTUtil.kt
@@ -6,6 +6,7 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import mu.KotlinLogging
 import wisoft.io.quotation.domain.User
+import wisoft.io.quotation.exception.error.InvalidJwtTokenException
 import java.io.File
 import java.util.*
 
@@ -55,6 +56,7 @@ object JWTUtil {
             claims.body.expiration.after(currentDate)
         }.onFailure {
             logger.error { "verifyToken fail: param[token: ${token}]" }
+            throw InvalidJwtTokenException(it.toString())
         }.getOrThrow()
     }
 

--- a/src/main/kotlin/wisoft/io/quotation/util/annotation/Authenticated.kt
+++ b/src/main/kotlin/wisoft/io/quotation/util/annotation/Authenticated.kt
@@ -1,0 +1,3 @@
+package wisoft.io.quotation.util.annotation
+
+annotation class Authenticated()

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -150,13 +150,13 @@ class UserControllerTest(
         test("deleteUser 성공") {
             // given
             val existUserEntity = repository.save(getUserEntityFixture())
-            val existUser = existUserEntity.to()
+            val existUser = existUserEntity.toDomain()
             val accessToken = JWTUtil.generateAccessToken(existUser)
 
             val result = mockMvc.perform(
                 MockMvcRequestBuilders.delete("/users/${existUserEntity.id}")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", accessToken)
+                    .header("Authorization", "Bearer $accessToken")
             )
                 .andExpect(MockMvcResultMatchers.status().isNoContent)
         }
@@ -168,7 +168,7 @@ class UserControllerTest(
                 MockMvcRequestBuilders.delete("/users/${existUser.id}")
                     .contentType(MediaType.APPLICATION_JSON)
             )
-                .andExpect( MockMvcResultMatchers.status().isUnauthorized)
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized)
         }
         test("deleteUser 실패 - 인증 정보 불일치 사용자") {
             // given

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -22,6 +22,7 @@ import wisoft.io.quotation.exception.error.ErrorData
 import wisoft.io.quotation.exception.error.http.HttpMessage
 import wisoft.io.quotation.fixture.entity.getUserEntityFixture
 import wisoft.io.quotation.util.JWTUtil
+import wisoft.io.quotation.util.SaltUtil
 
 @SpringBootTest
 @ContextConfiguration(classes = [DatabaseContainerConfig::class])
@@ -148,13 +149,38 @@ class UserControllerTest(
     context("deleteUser Test") {
         test("deleteUser 성공") {
             // given
+            val existUserEntity = repository.save(getUserEntityFixture())
+            val existUser = existUserEntity.to()
+            val accessToken = JWTUtil.generateAccessToken(existUser)
+
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/${existUserEntity.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", accessToken)
+            )
+                .andExpect(MockMvcResultMatchers.status().isNoContent)
+        }
+        test("deleteUser 실패 - 비 인가된 사용자") {
+            // given
             val existUser = repository.save(getUserEntityFixture())
 
             val result = mockMvc.perform(
                 MockMvcRequestBuilders.delete("/users/${existUser.id}")
                     .contentType(MediaType.APPLICATION_JSON)
             )
-                .andExpect(MockMvcResultMatchers.status().isNoContent)
+                .andExpect( MockMvcResultMatchers.status().isUnauthorized)
+        }
+        test("deleteUser 실패 - 인증 정보 불일치 사용자") {
+            // given
+            val existUser = repository.save(getUserEntityFixture())
+            val accessToken = "testToken"
+
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/${existUser.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", accessToken)
+            )
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
         }
     }
 


### PR DESCRIPTION
<!--아래 양식에 따라 작성하되 불필요한 항목은 삭제하고, 필요한 항목은 추가한다.-->

# 요구사항 및 기능 요약
로그인 상태 확인을 위한 AuthInterceptor를 만들었고, User 삭제의 경우 로그인 상태일때만 할 수 있도록 허용


# 관련 자료
- 설계 자료 - [노션 링크](https://www.notion.so/AuthInterceptor-49d29f9530bb4997bdc740157cddffc4?pvs=4)

# 작업 종류
- [x] 기능 추가
- [x] 기타 사소한 수정

# 코드 리뷰 시 참고 사항
AuthInterceptor 구현은 preHandle에서 이루어짐.
여기에서 토큰 검사가 이루어지는데, 내부 토큰 예외를 어떻게 처리할지 생각해볼 필요가 있음.
* 현재는 JWT Util에서 예외 처리가 이루어지고, 내부 예외를 받아서 Message로 보여줌

# 테스트 정도
- [x] 통합 테스트
