### PR TITLE
[TKT-48] #37/feat/update user

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import wisoft.io.quotation.application.port.`in`.*
@@ -19,7 +20,8 @@ class UserController(
     val signInUseCase: SignInUseCase,
     val deleteUserUseCase: DeleteUserUseCase,
     val getUserUseCase: GetUserUseCase,
-    val getUserDetailUseCase: GetUserDetailUseCase
+    val getUserDetailUseCase: GetUserDetailUseCase,
+    val updateUserUseCase: UpdateUserUseCase
 ) {
 
     @PostMapping("/users")
@@ -71,6 +73,20 @@ class UserController(
                     data = response
                 )
             )
+    }
+
+    @PutMapping("/users/{id}")
+    @Authenticated
+    fun updateUser(
+        @PathVariable("id") id: String,
+        @RequestBody @Valid request: UpdateUserUseCase.UpdateUserRequest
+    ): ResponseEntity<UpdateUserUseCase.UpdateUserResponse> {
+        val response = updateUserUseCase.updateUser(id, request)
+        return ResponseEntity.status(HttpStatus.OK).body(
+            UpdateUserUseCase.UpdateUserResponse(
+                data = UpdateUserUseCase.Data(response)
+            )
+        )
     }
 
     @DeleteMapping("/users/{id}")

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/UserAdaptor.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/UserAdaptor.kt
@@ -9,7 +9,7 @@ import wisoft.io.quotation.domain.User
 @Component
 class UserAdaptor(
     val userRepository: UserRepository,
-) : GetUserByIdPort, CreateUserPort, GetUserByNicknamePort {
+) : GetUserByIdPort, CreateUserPort, GetUserByNicknamePort, UpdateUserPort {
 
     override fun create(user: User): String {
         return userRepository.save(user.toEntity()).id
@@ -23,5 +23,9 @@ class UserAdaptor(
     override fun getByNicknameOrNull(nickname: String): User? {
         val userEntity = userRepository.findByNickname(nickname)
         return userEntity?.toDomain()
+    }
+
+    override fun update(user: User): String {
+        return userRepository.save(user.toEntity()).id
     }
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/UpdateUserUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/UpdateUserUseCase.kt
@@ -1,0 +1,22 @@
+package wisoft.io.quotation.application.port.`in`
+
+interface UpdateUserUseCase {
+
+    fun updateUser(id: String, request: UpdateUserRequest): String
+
+    data class UpdateUserRequest(
+        val nickname: String?,
+        val profile: String?,
+        val alarm: Boolean?,
+        val favoriteQuotation: String?,
+        val favoriteAuthor: String?,
+    )
+
+    data class UpdateUserResponse(
+        val data: Data
+    )
+
+    data class Data(
+        val id: String
+    )
+}

--- a/src/main/kotlin/wisoft/io/quotation/application/port/out/UpdateUserPort.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/out/UpdateUserPort.kt
@@ -1,0 +1,7 @@
+package wisoft.io.quotation.application.port.out
+
+import wisoft.io.quotation.domain.User
+
+interface UpdateUserPort {
+    fun update(user: User): String
+}

--- a/src/main/kotlin/wisoft/io/quotation/domain/User.kt
+++ b/src/main/kotlin/wisoft/io/quotation/domain/User.kt
@@ -2,6 +2,8 @@ package wisoft.io.quotation.domain
 
 import org.mindrot.jbcrypt.BCrypt
 import wisoft.io.quotation.adaptor.out.persistence.entity.UserEntity
+import wisoft.io.quotation.application.port.`in`.UpdateUserUseCase
+import wisoft.io.quotation.domain.dto.RelatedUserDto
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
@@ -26,16 +28,16 @@ data class User(
     val id: String,
     var password: String = "",
     var nickname: String,
-    val profilePath: String? = null,
-    val favoriteQuotation: String? = null,
-    val favoriteAuthor: String? = null,
-    val commentAlarm: Boolean = false,
-    val quotationAlarm: Boolean = false,
-    val quotationAlarmTimes: List<Timestamp> = emptyList(),
+    var profilePath: String? = null,
+    var favoriteQuotation: String? = null,
+    var favoriteAuthor: String? = null,
+    var commentAlarm: Boolean = false,
+    var quotationAlarm: Boolean = false,
+    var quotationAlarmTimes: List<Timestamp> = emptyList(),
     val createdTime: Timestamp = Timestamp.valueOf(LocalDateTime.now()),
-    val lastModifiedTime: Timestamp? = null,
-    val identityVerificationQuestion: String,
-    val identityVerificationAnswer: String
+    var lastModifiedTime: Timestamp? = null,
+    var identityVerificationQuestion: String,
+    var identityVerificationAnswer: String
 ) {
     fun toEntity(): UserEntity {
         return UserEntity(
@@ -70,4 +72,14 @@ data class User(
     fun resign(identifier: String) {
         this.nickname = "leaved#$identifier"
     }
+
+    fun update(dto: RelatedUserDto.UpdateUserDto) {
+        dto.nickname?.let { this.nickname = it }
+        dto.profile?.let { this.profilePath = it }
+        dto.favoriteAuthor?.let { this.favoriteAuthor = it }
+        dto.favoriteQuotation?.let { this.favoriteQuotation = it }
+        dto.alarm?.let { this.quotationAlarm = it }
+    }
+
+
 }

--- a/src/main/kotlin/wisoft/io/quotation/domain/dto/RelatedUserDto.kt
+++ b/src/main/kotlin/wisoft/io/quotation/domain/dto/RelatedUserDto.kt
@@ -1,0 +1,11 @@
+package wisoft.io.quotation.domain.dto
+
+class RelatedUserDto {
+    data class UpdateUserDto(
+        val nickname: String?,
+        val profile: String?,
+        val alarm: Boolean?,
+        val favoriteQuotation: String?,
+        val favoriteAuthor: String?,
+    )
+}

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -209,8 +209,9 @@ class UserControllerTest(
         test("updateUser 성공 ") {
             // given
             val existUser = repository.save(getUserEntityFixture())
+            val expectedNickname = "updatedNickname"
             val request = UpdateUserUseCase.UpdateUserRequest(
-                nickname = "updatedNickname",
+                nickname = expectedNickname,
                 null,
                 null,
                 null,
@@ -232,6 +233,13 @@ class UserControllerTest(
             // then
             val actual = objectMapper.readValue(result, UpdateUserUseCase.UpdateUserResponse::class.java)
             actual.data.id shouldBe existUser.id
+
+            val actualUser = repository.findById(existUser.id).get()
+            println(actualUser)
+
+            actualUser.nickname shouldBe expectedNickname
         }
     }
+
+
 })

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -15,10 +15,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.testcontainers.junit.jupiter.Testcontainers
 import wisoft.io.quotation.DatabaseContainerConfig
 import wisoft.io.quotation.adaptor.out.persistence.repository.UserRepository
-import wisoft.io.quotation.application.port.`in`.CreateUserUseCase
-import wisoft.io.quotation.application.port.`in`.GetUserDetailUseCase
-import wisoft.io.quotation.application.port.`in`.GetUserUseCase
-import wisoft.io.quotation.application.port.`in`.SignInUseCase
+import wisoft.io.quotation.application.port.`in`.*
 import wisoft.io.quotation.exception.error.ErrorData
 import wisoft.io.quotation.exception.error.http.HttpMessage
 import wisoft.io.quotation.fixture.entity.getUserEntityFixture
@@ -205,11 +202,36 @@ class UserControllerTest(
             actual.data.nickname shouldBe existUser.nickname
             actual.data.bookmarkCount shouldBe 0
             actual.data.likeQuotationCount shouldBe 0
-
-
-
-
         }
     }
 
+    context("updateUser Test") {
+        test("updateUser 성공 ") {
+            // given
+            val existUser = repository.save(getUserEntityFixture())
+            val request = UpdateUserUseCase.UpdateUserRequest(
+                nickname = "updatedNickname",
+                null,
+                null,
+                null,
+                null
+            )
+            val accessToken = JWTUtil.generateAccessToken(existUser.toDomain())
+            // when
+            val requestToJson = objectMapper.writeValueAsString(request)
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.put("/users/${existUser.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer $accessToken")
+                    .content(requestToJson)
+            ).andExpect(
+                MockMvcResultMatchers.status().isOk
+            ).andReturn()
+                .response.contentAsString
+
+            // then
+            val actual = objectMapper.readValue(result, UpdateUserUseCase.UpdateUserResponse::class.java)
+            actual.data.id shouldBe existUser.id
+        }
+    }
 })


### PR DESCRIPTION
# 요구사항 및 기능 요약
User Update API를 구현했습니다. RequestBody에 필요한 값만 넣으면 해당 값을 기반으로 변경이 이루어지도록 했습니다.


# 관련 자료
- 설계 자료 - [노션 링크](https://www.notion.so/a03b6c4ed47b4f42899fa33b848ef482?pvs=4)

# 작업 종류
- [x] 기능 추가

# 코드 리뷰 시 참고 사항
1. RelatedUserDto 사용
Request를 그대로 가져다 User Domain의 기능으로 구현하려다가, Request정보가 도메인까지 영향을 미치는 것에 대해서 아닌 거같아서 Domain에 DTO 패키지를 두고 RelatedUserDto는 Data Class로 만들고 하위에 UpdateUserDto를 새로 제작.
Update API의 Request는 비지니스 영역에서 해당 UpdateUserDto로 변환하고, user.update(dto)를 호출하는 방식으로 사용
  * 해당 내용에 대해서 의견을 주셨으면 좋겠습니다.

2. API 명세서 기능 추가 누락
API 명세서를 기반으로 현재 User 변경 API를 구성해두었는데, 실제로 변경되어야 하는 부분이 더 많아 보입니다.
[API 명세서](https://www.notion.so/a51255ece6f64e178a5745b226b3f99f?pvs=4)
```json
"nickname": "String",
"profile": "String (base64 encoding)",
"alarm": "Boolean",
"favoriteQuotation": "String",
"favoriteAuthor": "String",
```

에서,
```json
"commentAlarm": "",
"identityVerificationQuestion": "",
"identityVerificationAnswer": "",
```
가 추가되어야 할 것으로 보입니다. 동의하시면 해당 내용을 추가 해서 Merge하겠습니다.


# 테스트 정도
- [x] 통합 테스트
