### PR TITLE
[TKT-63, TKT-64] #49/feature/validate user,reset password

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
@@ -24,6 +24,7 @@ class UserController(
     val getUserDetailUseCase: GetUserDetailUseCase,
     val getUserListUseCase: GetUserListUseCase,
     val updateUserUseCase: UpdateUserUseCase,
+    val validateUserUesCase: ValidateUserUesCase
 ) {
 
     @PostMapping("/users")
@@ -88,6 +89,19 @@ class UserController(
                 )
             )
     }
+
+    @PostMapping("/users/identity-verification")
+    fun validateUser(
+        @RequestBody @Valid request: ValidateUserUesCase.ValidateUserRequest
+    ): ResponseEntity<ValidateUserUesCase.ValidateUserResponse> {
+        val response = validateUserUesCase.validateUser(request)
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ValidateUserUesCase.ValidateUserResponse(
+                data = response
+            )
+        )
+    }
+
 
     @PutMapping("/users/{id}")
     @Authenticated

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/interceptor/AuthInterceptor.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/interceptor/AuthInterceptor.kt
@@ -8,22 +8,60 @@ import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.HandlerInterceptor
 import wisoft.io.quotation.exception.error.UnauthorizedUserException
 import wisoft.io.quotation.util.JWTUtil
-import wisoft.io.quotation.util.annotation.Authenticated
+import wisoft.io.quotation.util.annotation.LoginAuthenticated
+import wisoft.io.quotation.util.annotation.ResetPasswordAuthenticated
 
 @Component
 class AuthInterceptor : HandlerInterceptor {
     val logger = KotlinLogging.logger {}
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
-        if (handler !is HandlerMethod) return true
-        handler.getMethodAnnotation(Authenticated::class.java) ?: return true
 
+        if (handler !is HandlerMethod) return true
+        println(request.requestURI)
+        val loginAuthenticated = handler.getMethodAnnotation(LoginAuthenticated::class.java)
+        val resetPasswordAuthenticated = handler.getMethodAnnotation(ResetPasswordAuthenticated::class.java)
+
+        if (loginAuthenticated != null) {
+            return loginAuthCheck(request)
+        }
+        if (resetPasswordAuthenticated != null) {
+            return resetPasswordAuthCheck(request)
+        }
+        return true
+    }
+
+    private fun loginAuthCheck(request: HttpServletRequest): Boolean {
         return runCatching {
-            val authHeader = request.getHeader("Authorization") ?: throw UnauthorizedUserException("Authorization Not Found")
+            val authHeader =
+                request.getHeader("Authorization") ?: throw UnauthorizedUserException("Authorization Not Found")
             val token = authHeader.substringAfter("Bearer ")
 
-            JWTUtil.verifyToken(token)
+            JWTUtil.verifyAccessToken(token)
+
+            val userId = JWTUtil.extractUserIdByToken(token)
+            request.setAttribute("userId", userId)
+
+            true
         }.onFailure {
-            logger.error { "preHandle fail" }
+            logger.error { "loginAuthCheck fail" }
+        }.getOrThrow()
+    }
+
+    private fun resetPasswordAuthCheck(request: HttpServletRequest): Boolean {
+        return runCatching {
+            val authHeader =
+                request.getHeader("Authorization") ?: throw UnauthorizedUserException("Authorization Not Found")
+            val token = authHeader.substringAfter("Bearer ")
+
+            JWTUtil.verifyResetPasswordToken(token)
+
+            val userId = JWTUtil.extractUserIdByToken(token)
+            request.setAttribute("userId", userId)
+
+            true
+        }.onFailure {
+            logger.error { "resetPasswordAuthCheck fail" }
         }.getOrThrow()
     }
 }
+

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/UserAdaptor.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/UserAdaptor.kt
@@ -38,4 +38,12 @@ class UserAdaptor(
         val userEntityList: List<UserEntity> = userRepository.findAllByNicknameContains(nickname)
         return userEntityList.map { it.toDomain() }
     }
+
+    override fun getUserByIdentityInformation(id: String, question: String, answer: String): User? {
+        val userEntity =
+            userRepository.findByIdAndIdentityVerificationQuestionAndIdentityVerificationAnswer(
+                id, question, answer
+            )
+        return userEntity?.toDomain()
+    }
 }

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/repository/UserRepository.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/repository/UserRepository.kt
@@ -9,4 +9,10 @@ interface UserRepository : JpaRepository<UserEntity, String> {
     fun findByNickname(nickname: String): UserEntity?
     fun findAllByNicknameContains(nickname: String): List<UserEntity>
 
+    fun findByIdAndIdentityVerificationQuestionAndIdentityVerificationAnswer(
+        nickname: String,
+        identityVerificationQuestion: String,
+        identityVerificationAnswer: String
+    ): UserEntity?
+
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/ResetPasswordUserUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/ResetPasswordUserUseCase.kt
@@ -1,0 +1,30 @@
+package wisoft.io.quotation.application.port.`in`
+
+import jakarta.validation.constraints.NotBlank
+
+interface ResetPasswordUserUseCase {
+
+    fun resetPasswordUser(request: ResetPasswordUserRequest): String
+
+    data class ResetPasswordUserRequest(
+        val password: String,
+        val passwordConfirm: String,
+        val userId: String,
+    )
+
+    data class ResetPasswordUserRequestBody(
+        @field:NotBlank
+        val password: String,
+        @field:NotBlank
+        val passwordConfirm: String
+    )
+
+    data class ResetPasswordUserResponse(
+        val data: Data
+    )
+
+    data class Data(
+        val id: String
+    )
+
+}

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/ValidateUserUesCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/ValidateUserUesCase.kt
@@ -2,29 +2,23 @@ package wisoft.io.quotation.application.port.`in`
 
 import jakarta.validation.constraints.NotBlank
 
-interface CreateUserUseCase {
+interface ValidateUserUesCase {
+    fun validateUser(request: ValidateUserRequest): Data
 
-    fun createUser(request: CreateUserRequest): String
-
-    data class CreateUserRequest(
+    data class ValidateUserRequest(
         @field:NotBlank
         val id: String,
-        @field:NotBlank
-        val password: String,
-        @field:NotBlank
-        val nickname: String,
         @field:NotBlank
         val identityVerificationQuestion: String,
         @field:NotBlank
         val identityVerificationAnswer: String
     )
 
-    data class CreateUserResponse(
+    data class ValidateUserResponse(
         val data: Data,
     )
 
     data class Data(
-        val id: String
+        val passwordResetToken: String
     )
-
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/out/GetUserPort.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/out/GetUserPort.kt
@@ -6,5 +6,6 @@ interface GetUserPort {
 
     fun getUserById(id: String): User?
     fun getUserByNickname(nickname: String): User?
+    fun getUserByIdentityInformation(id: String, question: String, answer: String): User?
 
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
@@ -7,6 +7,7 @@ import wisoft.io.quotation.application.port.`in`.*
 import wisoft.io.quotation.application.port.out.*
 import wisoft.io.quotation.domain.User
 import wisoft.io.quotation.exception.error.InvalidRequestParameterException
+import wisoft.io.quotation.exception.error.InvalidUserException
 import wisoft.io.quotation.exception.error.UserDuplicateException
 import wisoft.io.quotation.exception.error.UserNotFoundException
 import wisoft.io.quotation.util.JWTUtil
@@ -24,7 +25,8 @@ class UserService(
     val updateUserPort: UpdateUserPort,
     val deleteUserPort: DeleteUserPort
 ) : CreateUserUseCase, SignInUseCase,
-    DeleteUserUseCase, GetUserUseCase, GetUserDetailUseCase, UpdateUserUseCase, GetUserListUseCase {
+    DeleteUserUseCase, GetUserUseCase, GetUserDetailUseCase, UpdateUserUseCase, GetUserListUseCase,
+    ValidateUserUesCase {
     val logger = KotlinLogging.logger {}
 
     @Transactional
@@ -56,7 +58,13 @@ class UserService(
     override fun getUserList(request: GetUserListUseCase.GetUserListRequest): List<GetUserListUseCase.UserDto> {
         return runCatching {
             val userList = getUserListPort.getUserList(request.nickname)
-            userList.map { GetUserListUseCase.UserDto(id = it.id, nickname = it.nickname, profilePath = it.profilePath) }
+            userList.map {
+                GetUserListUseCase.UserDto(
+                    id = it.id,
+                    nickname = it.nickname,
+                    profilePath = it.profilePath
+                )
+            }
         }.onFailure {
             logger.error { "getUserList fail: param[$request]" }
         }.getOrThrow()
@@ -152,5 +160,21 @@ class UserService(
         }.getOrThrow()
     }
 
+    override fun validateUser(request: ValidateUserUesCase.ValidateUserRequest): ValidateUserUesCase.Data {
+        return runCatching {
+            val user = getUserPort.getUserByIdentityInformation(
+                request.id,
+                request.identityVerificationQuestion,
+                request.identityVerificationAnswer
+            ) ?: throw InvalidUserException("request: ${request}")
 
+            val passwordResetToken = JWTUtil.generatePasswordResetToken(user)
+
+            ValidateUserUesCase.Data(passwordResetToken = passwordResetToken)
+        }
+            .onFailure {
+                logger.error { "validateUser fail: param[${request}]" }
+            }
+            .getOrThrow()
+    }
 }

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/InvalidUserException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/InvalidUserException.kt
@@ -1,0 +1,6 @@
+package wisoft.io.quotation.exception.error
+
+import wisoft.io.quotation.exception.error.http.NotFoundException
+
+class InvalidUserException(override val value: String) : NotFoundException(value = value) {
+}

--- a/src/main/kotlin/wisoft/io/quotation/util/YmlConfig.kt
+++ b/src/main/kotlin/wisoft/io/quotation/util/YmlConfig.kt
@@ -30,12 +30,14 @@ data class YmlConfig(
         data class ApplicationConfig(
             @JsonProperty("name") val name: String
         )
+
         data class DataSourceConfig(
             @JsonProperty("url") val url: String,
             @JsonProperty("username") val username: String,
             @JsonProperty("password") val password: String,
             @JsonProperty("driver-class-name") val driverClassName: String
         )
+
         data class JpaConfig(
             @JsonProperty("hibernate") val hibernate: HibernateConfig,
             @JsonProperty("properties") val properties: PropertiesConfig,
@@ -44,6 +46,7 @@ data class YmlConfig(
             data class HibernateConfig(
                 @JsonProperty("ddl-auto") val ddlAuto: String,
             )
+
             data class PropertiesConfig(
                 @JsonProperty("hibernate") val hibernate: PropertiesHibernateConfig
             ) {
@@ -62,7 +65,9 @@ data class YmlConfig(
         data class JwtConfig(
             @JsonProperty("secret-key") val secretKey: String,
             @JsonProperty("access-token-expiration-time") val accessTokenExpirationTime: Long,
-            @JsonProperty("refresh-token-expiration-time") val refreshTokenExpirationTime: Long
+            @JsonProperty("refresh-token-expiration-time") val refreshTokenExpirationTime: Long,
+            @JsonProperty("password-refresh-token-expiration-time")
+            val passwordRefreshTokenExpirationTime: Long
         )
     }
 }

--- a/src/main/kotlin/wisoft/io/quotation/util/annotation/LoginAuthenticated.kt
+++ b/src/main/kotlin/wisoft/io/quotation/util/annotation/LoginAuthenticated.kt
@@ -1,3 +1,3 @@
 package wisoft.io.quotation.util.annotation
 
-annotation class Authenticated()
+annotation class LoginAuthenticated()

--- a/src/main/kotlin/wisoft/io/quotation/util/annotation/ResetPasswordAuthenticated.kt
+++ b/src/main/kotlin/wisoft/io/quotation/util/annotation/ResetPasswordAuthenticated.kt
@@ -1,0 +1,3 @@
+package wisoft.io.quotation.util.annotation
+
+annotation class ResetPasswordAuthenticated()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,3 +33,5 @@ environment:
     access-token-expiration-time: 3600000
     # 토큰 만료 시간 (1주일)
     refresh-token-expiration-time: 604800000
+    # 토큰 만료 시간 (5분)
+    password-refresh-token-expiration-time: 300000

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -114,8 +114,8 @@ class UserControllerTest(
 
             val userIdByAccessToken = JWTUtil.extractUserIdByToken(actual.data.accessToken)
             val userIdByRefreshToken = JWTUtil.extractUserIdByToken(actual.data.refreshToken)
-            userIdByAccessToken shouldBe existUser.nickname
-            userIdByRefreshToken shouldBe existUser.nickname
+            userIdByAccessToken shouldBe existUser.id
+            userIdByRefreshToken shouldBe existUser.id
         }
     }
 
@@ -281,10 +281,54 @@ class UserControllerTest(
             val actual = objectMapper.readValue(result, GetUserListUseCase.GetUserListResponse::class.java)
             val actualUserDto = actual.data.users[0]
 
-            actualUserDto.id shouldBe  existUser.id
-            actualUserDto.nickname shouldBe  existUser.nickname
-            actualUserDto.profilePath shouldBe  existUser.profilePath
+            actualUserDto.id shouldBe existUser.id
+            actualUserDto.nickname shouldBe existUser.nickname
+            actualUserDto.profilePath shouldBe existUser.profilePath
 
+        }
+    }
+
+    context("validateUser Test") {
+        test("validateUser 성공 ") {
+            // given
+            val existUser = repository.save(getUserEntityFixture())
+            val request = ValidateUserUesCase.ValidateUserRequest(
+                existUser.id, existUser.identityVerificationQuestion, existUser.identityVerificationAnswer
+            )
+
+            // when
+            val validateUserRequestJson = objectMapper.writeValueAsString(request)
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.post("/users/identity-verification")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(validateUserRequestJson)
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+                .response.contentAsString
+
+            // then
+            val actual = objectMapper.readValue(result, ValidateUserUesCase.ValidateUserResponse::class.java)
+
+            val actualUserId = JWTUtil.extractUserIdByToken(actual.data.passwordResetToken)
+            actualUserId shouldBe existUser.id
+        }
+
+        test("validateUser 실패 - 해당하는 대답이 아님 ") {
+            // given
+            val existUser = repository.save(getUserEntityFixture())
+            val request = ValidateUserUesCase.ValidateUserRequest(
+                existUser.id, existUser.identityVerificationQuestion, "NotMatchingAnswer"
+            )
+
+            // when, then
+            val validateUserRequestJson = objectMapper.writeValueAsString(request)
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/users/identity-verification")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(validateUserRequestJson)
+            ).andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andReturn()
+                .response.contentAsString
         }
     }
 

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -313,7 +313,7 @@ class UserControllerTest(
             actualUserId shouldBe existUser.id
         }
 
-        test("validateUser 실패 - 해당하는 대답이 아님 ") {
+        test("validateUser 실패 - ID, 질문, 대답 Data가 존재하는 것과 한개라도 다름 ") {
             // given
             val existUser = repository.save(getUserEntityFixture())
             val request = ValidateUserUesCase.ValidateUserRequest(
@@ -329,6 +329,97 @@ class UserControllerTest(
             ).andExpect(MockMvcResultMatchers.status().isNotFound)
                 .andReturn()
                 .response.contentAsString
+        }
+    }
+
+    context("resetPasswordUser Test") {
+        test("resetPasswordUser 성공") {
+            // given
+            val existUser = repository.save(getUserEntityFixture()).toDomain()
+            val expectedPassword = "resetPassword"
+            val request = ResetPasswordUserUseCase.ResetPasswordUserRequestBody(
+                expectedPassword, expectedPassword
+            )
+            val resetPasswordToken = JWTUtil.generatePasswordResetToken(existUser)
+
+            // when
+            val resetPasswordRequestBodyJson = objectMapper.writeValueAsString(request)
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.patch("/users/${existUser.id}/reset-password")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer $resetPasswordToken")
+                    .content(resetPasswordRequestBodyJson)
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+                .response.contentAsString
+
+            // then
+            val actual =
+                objectMapper.readValue(result, ResetPasswordUserUseCase.ResetPasswordUserResponse::class.java)
+
+            actual.data.id shouldBe existUser.id
+            val actualUser = repository.findById(existUser.id).get().toDomain()
+            actualUser.isCorrectPassword(expectedPassword) shouldBe true
+
+        }
+
+        test("resetPasswordUser 실패 - RefreshToken이 없는 경우") {
+            // given
+            val existUser = repository.save(getUserEntityFixture()).toDomain()
+            val expectedStatus = HttpMessage.HTTP_401.status
+            val expectedPath = "/users/${existUser.id}/reset-password"
+
+            val expectedPassword = "resetPassword"
+            val request = ResetPasswordUserUseCase.ResetPasswordUserRequestBody(
+                expectedPassword, expectedPassword
+            )
+
+
+            // when
+            val resetPasswordRequestBodyJson = objectMapper.writeValueAsString(request)
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.patch("/users/${existUser.id}/reset-password")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(resetPasswordRequestBodyJson)
+            ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+                .andReturn()
+                .response.contentAsString
+
+            // then
+            val actual = objectMapper.readValue(result, ErrorData::class.java).data
+            actual.status shouldBe expectedStatus.value()
+            actual.error shouldBe expectedStatus.reasonPhrase
+            actual.path shouldBe expectedPath
+        }
+
+        test("resetPasswordUser 실패 - RefreshToken이 아닌 다른 토큰이 온 경우") {
+            // given
+            val existUser = repository.save(getUserEntityFixture()).toDomain()
+            val expectedStatus = HttpMessage.HTTP_403.status
+            val expectedPath = "/users/${existUser.id}/reset-password"
+            val accessToken = JWTUtil.generateAccessToken(existUser)
+
+            val expectedPassword = "resetPassword"
+            val request = ResetPasswordUserUseCase.ResetPasswordUserRequestBody(
+                expectedPassword, expectedPassword
+            )
+
+            // when
+            val resetPasswordRequestBodyJson = objectMapper.writeValueAsString(request)
+            val result = mockMvc.perform(
+                MockMvcRequestBuilders.patch("/users/${existUser.id}/reset-password")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer $accessToken")
+                    .content(resetPasswordRequestBodyJson)
+            ).andExpect(MockMvcResultMatchers.status().isForbidden)
+                .andReturn()
+                .response.contentAsString
+
+            // then
+            val actual = objectMapper.readValue(result, ErrorData::class.java).data
+            actual.status shouldBe expectedStatus.value()
+            actual.error shouldBe expectedStatus.reasonPhrase
+            actual.path shouldBe expectedPath
         }
     }
 


### PR DESCRIPTION
# 요구사항 및 기능 요약
User가 비밀번호 초기화를 위한 본인 확인 질문과 응답을 작성하고, 인가된 경우 5분동안 유효한 JWT Token을 이용해서 비밀번호 초기화 API를 사용할 수 있다.

# 관련 자료
- 설계 자료 - [본인 인증 API](https://www.notion.so/User-API-dc1006dc083a4cffbab01d52e5eebbbf?pvs=4), [비밀번호 초기화 API](https://www.notion.so/User-API-6251b0c8aaa844658ab2b2bff2651727?pvs=4)

# 작업 종류
<!--이 PR에서 작업한 항목을 모두 체크
되도록 한 PR에서는 하나의 작업을 체크하도록 구성-->
- [x] 기능 추가

# 코드 리뷰 시 참고 사항

# 테스트 정도
- [x] 통합 테스트
