### PR TITLE
[TKT-91] #59/fix/duplicateException

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/exception/error/ErrorMessage.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/ErrorMessage.kt
@@ -4,10 +4,9 @@ import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.MethodArgumentNotValidException
 import java.sql.Timestamp
-import java.time.LocalDateTime
 
 data class ErrorMessage(
-    val timestamp: Timestamp = Timestamp(LocalDateTime.now().second.toLong()),
+    val timestamp: Timestamp = Timestamp(System.currentTimeMillis()),
     val status: Int,
     val error: String,
     val path: String,

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/UserDuplicateException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/UserDuplicateException.kt
@@ -1,5 +1,5 @@
 package wisoft.io.quotation.exception.error
 
-import wisoft.io.quotation.exception.error.http.BadRequestException
+import wisoft.io.quotation.exception.error.http.DuplicateException
 
-class UserDuplicateException(override val value: String) : BadRequestException(value = value)
+class UserDuplicateException(override val value: String) : DuplicateException(value = value)

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/http/DuplicateException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/http/DuplicateException.kt
@@ -1,7 +1,7 @@
 package wisoft.io.quotation.exception.error.http
 
-open class ForbiddenException(
+open class DuplicateException(
     open val value: String,
 ) : Throwable(
-        message = value + HttpMessage.HTTP_403.message,
+        message = value + HttpMessage.HTTP_400_DUPLICATE.message,
     )

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/http/HttpMessage.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/http/HttpMessage.kt
@@ -7,7 +7,8 @@ enum class HttpMessage(
     val message: String,
 ) {
     HTTP_400(HttpStatus.BAD_REQUEST, " 잘못된 요청입니다."),
-    HTTP_401(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
-    HTTP_403(HttpStatus.FORBIDDEN, "사용자는콘텐츠에 접근할 권리를 가지고 있지 않습니다."),
+    HTTP_400_DUPLICATE(HttpStatus.BAD_REQUEST, " 중복 자원입니다."),
+    HTTP_401(HttpStatus.UNAUTHORIZED, " 인증되지 않은 사용자입니다."),
+    HTTP_403(HttpStatus.FORBIDDEN, " 사용자는 콘텐츠에 접근할 권리를 가지고 있지 않습니다."),
     HTTP_404(HttpStatus.NOT_FOUND, " 리소스가 존재하지 않습니다."),
 }

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/http/UnauthorizedException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/http/UnauthorizedException.kt
@@ -3,5 +3,5 @@ package wisoft.io.quotation.exception.error.http
 open class UnauthorizedException(
     open val value: String,
 ) : Throwable(
-        message = value + HttpMessage.HTTP_401,
+        message = value + HttpMessage.HTTP_401.message,
     )

--- a/src/main/kotlin/wisoft/io/quotation/exception/handler/ExceptionHandler.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/handler/ExceptionHandler.kt
@@ -74,4 +74,17 @@ class ExceptionHandler {
             .status(status)
             .body(errorMessage)
     }
+
+    @ExceptionHandler(DuplicateException::class)
+    fun duplicateExceptionHandler(
+        e: DuplicateException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ErrorData> {
+        val status = HttpMessage.HTTP_400_DUPLICATE.status
+        val errorMessage = ErrorData(ErrorMessage.from(status, e, request))
+
+        return ResponseEntity
+            .status(status)
+            .body(errorMessage)
+    }
 }


### PR DESCRIPTION
중복에 대한 명확한 메시지를 작성하고 현재시간 표시에 대한 오류를 수정함

# 요구사항 및 기능 요약
* 중복 메시지를 중복된 자원임을 명시하는 방향으로 해결
* 예외 메시지 중 띄어쓰기가 없는 부분 체크해서 해결
* Timestamp를 정상적으로 반환하도록 내부 로직 수정



# 관련 자료
- 설계 자료 - [노션 링크](https://www.notion.so/Timestamp-676e865f1c98466c9245e0319180817d?pvs=4)

# 작업 종류
<!--이 PR에서 작업한 항목을 모두 체크
되도록 한 PR에서는 하나의 작업을 체크하도록 구성-->
- [x] 버그 수정
- [x] 기타 사소한 수정

# 코드 리뷰 시 참고 사항

# 테스트 정도
- [x] 통합 테스트
