### PR TITLE
[TKT-82] #61/feature/getUserMyPage

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
@@ -21,7 +21,8 @@ class UserController(
     val createUserUseCase: CreateUserUseCase,
     val signInUseCase: SignInUseCase,
     val deleteUserUseCase: DeleteUserUseCase,
-    val getUserDetailUseCase: GetUserDetailUseCase,
+    val getUserMyPageUseCase: GetUserMyPageUseCase,
+    val getUserPageUseCase: GetUserPageUseCase,
     val getUserListUseCase: GetUserListUseCase,
     val updateUserUseCase: UpdateUserUseCase,
     val validateUserUesCase: ValidateUserUesCase,
@@ -78,14 +79,28 @@ class UserController(
             )
     }
 
-    @GetMapping("/users/{id}")
-    fun getUserDetail(
+    @GetMapping("/users/{id}/my-page")
+    @LoginAuthenticated
+    fun getUserMyPage(
         @PathVariable("id") id: String,
-    ): ResponseEntity<GetUserDetailUseCase.GetUserDetailByIdResponse> {
-        val response = getUserDetailUseCase.getUserDetailById(GetUserDetailUseCase.GetUserDetailByIdRequest(id))
+    ): ResponseEntity<GetUserMyPageUseCase.GetUserMyPageResponse> {
+        val response = getUserMyPageUseCase.getUserMyPage(GetUserMyPageUseCase.GetUserMyPageRequest(id))
         return ResponseEntity.status(HttpStatus.OK)
             .body(
-                GetUserDetailUseCase.GetUserDetailByIdResponse(
+                GetUserMyPageUseCase.GetUserMyPageResponse(
+                    data = response,
+                ),
+            )
+    }
+
+    @GetMapping("/users/{id}")
+    fun getUserPage(
+        @PathVariable("id") id: String,
+    ): ResponseEntity<GetUserPageUseCase.GetUserPageResponse> {
+        val response = getUserPageUseCase.getUserPage(GetUserPageUseCase.GetUserPageRequest(id))
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(
+                GetUserPageUseCase.GetUserPageResponse(
                     data = response,
                 ),
             )

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/GetUserMyPageUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/GetUserMyPageUseCase.kt
@@ -2,19 +2,19 @@ package wisoft.io.quotation.application.port.`in`
 
 import jakarta.validation.constraints.NotBlank
 
-interface GetUserDetailUseCase {
-    fun getUserDetailById(request: GetUserDetailByIdRequest): UserDetailDto
+interface GetUserMyPageUseCase {
+    fun getUserMyPage(request: GetUserMyPageRequest): UserMyPageDto
 
-    data class GetUserDetailByIdRequest(
+    data class GetUserMyPageRequest(
         @field:NotBlank
         val id: String,
     )
 
-    data class GetUserDetailByIdResponse(
-        val data: UserDetailDto,
+    data class GetUserMyPageResponse(
+        val data: UserMyPageDto,
     )
 
-    data class UserDetailDto(
+    data class UserMyPageDto(
         val id: String,
         val nickname: String,
         val profile: String? = null,

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/GetUserPageUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/GetUserPageUseCase.kt
@@ -1,0 +1,26 @@
+package wisoft.io.quotation.application.port.`in`
+
+import jakarta.validation.constraints.NotBlank
+
+interface GetUserPageUseCase {
+    fun getUserPage(request: GetUserPageRequest): UserPageDto
+
+    data class GetUserPageRequest(
+        @field:NotBlank
+        val id: String,
+    )
+
+    data class GetUserPageResponse(
+        val data: UserPageDto,
+    )
+
+    data class UserPageDto(
+        val id: String,
+        val nickname: String,
+        val profilePath: String? = null,
+        val favoriteQuotation: String? = null,
+        val favoriteAuthor: String? = null,
+        val bookmarkCount: Long,
+        val likeQuotationCount: Long,
+    )
+}

--- a/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
@@ -27,7 +27,8 @@ class UserService(
 ) : CreateUserUseCase,
     SignInUseCase,
     DeleteUserUseCase,
-    GetUserDetailUseCase,
+    GetUserMyPageUseCase,
+    GetUserPageUseCase,
     UpdateUserUseCase,
     GetUserListUseCase,
     ValidateUserUesCase,
@@ -116,12 +117,12 @@ class UserService(
         }.getOrThrow()
     }
 
-    override fun getUserDetailById(request: GetUserDetailUseCase.GetUserDetailByIdRequest): GetUserDetailUseCase.UserDetailDto {
+    override fun getUserMyPage(request: GetUserMyPageUseCase.GetUserMyPageRequest): GetUserMyPageUseCase.UserMyPageDto {
         return runCatching {
             val user = getUserPort.getUserById(request.id) ?: throw UserNotFoundException("id: ${request.id}")
             val bookmarkCount = getBookmarkListPort.getBookmarkListCountByUserId(request.id)
             val likeCount = getLikeListPort.getLikeListCountByUserId(request.id)
-            GetUserDetailUseCase.UserDetailDto(
+            GetUserMyPageUseCase.UserMyPageDto(
                 user.id,
                 user.nickname,
                 user.profilePath,
@@ -131,6 +132,25 @@ class UserService(
                 user.quotationAlarm,
                 bookmarkCount,
                 likeCount,
+            )
+        }.onFailure {
+            logger.error { "getUserDetailById fail: param[$request]" }
+        }.getOrThrow()
+    }
+
+    override fun getUserPage(request: GetUserPageUseCase.GetUserPageRequest): GetUserPageUseCase.UserPageDto {
+        return runCatching {
+            val user = getUserPort.getUserById(request.id) ?: throw UserNotFoundException("id: ${request.id}")
+            val bookmarkCount = getBookmarkListPort.getBookmarkListCountByUserId(request.id)
+            val likeCount = getLikeListPort.getLikeListCountByUserId(request.id)
+            GetUserPageUseCase.UserPageDto(
+                id = user.id,
+                nickname = user.nickname,
+                profilePath = user.profilePath,
+                favoriteQuotation = user.favoriteQuotation,
+                favoriteAuthor = user.favoriteAuthor,
+                bookmarkCount = bookmarkCount,
+                likeQuotationCount = likeCount,
             )
         }.onFailure {
             logger.error { "getUserDetailById fail: param[$request]" }


### PR DESCRIPTION
# 요구사항 및 기능 요약
로그인 현황에 따른 user 구분으로 mypage와 page로 구분해서 API를 설계함
user/:id/my-page로는 user의 알람정보를 포함해서 볼 수 있고, user/:id로는 알람정보 등의 정보는 볼 수 없음

# 관련 자료
- 설계 자료 - [노션 링크](https://www.notion.so/API-efdcdb8876d547c587ad688c7616aa1c?pvs=4)

# 작업 종류
- [x] 기능 추가
- [x] 기능 변경


# 코드 리뷰 시 참고 사항

# 테스트 정도
- [x] 통합 테스트
