### PR TITLE
[TKT-125] feat: Refresh Token 시간 수정과 재발급 API

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
@@ -9,17 +9,20 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import wisoft.io.quotation.application.port.`in`.user.*
 import wisoft.io.quotation.util.annotation.LoginAuthenticated
+import wisoft.io.quotation.util.annotation.RefreshTokenAuthenticated
 import wisoft.io.quotation.util.annotation.ResetPasswordAuthenticated
 
 @RestController
 class UserController(
     val createUserUseCase: CreateUserUseCase,
     val signInUseCase: SignInUseCase,
+    val refreshTokenUserUseCase: RefreshTokenUserUseCase,
     val deleteUserUseCase: DeleteUserUseCase,
     val getUserMyPageUseCase: GetUserMyPageUseCase,
     val getUserPageUseCase: GetUserPageUseCase,
@@ -72,6 +75,24 @@ class UserController(
                 SignInUseCase.SignInResponse(
                     data =
                         SignInUseCase.UserTokenDto(
+                            accessToken = response.accessToken,
+                            refreshToken = response.refreshToken,
+                        ),
+                ),
+            )
+    }
+
+    @PostMapping("/users/refresh-token")
+    @RefreshTokenAuthenticated
+    fun refreshToken(
+        @RequestAttribute("userId") userId: String,
+    ): ResponseEntity<RefreshTokenUserUseCase.RefreshTokenUserResponse> {
+        val response = refreshTokenUserUseCase.refreshToken(userId)
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(
+                RefreshTokenUserUseCase.RefreshTokenUserResponse(
+                    data =
+                        RefreshTokenUserUseCase.UserTokenDto(
                             accessToken = response.accessToken,
                             refreshToken = response.refreshToken,
                         ),

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/interceptor/AuthInterceptor.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/interceptor/AuthInterceptor.kt
@@ -65,7 +65,6 @@ class AuthInterceptor : HandlerInterceptor {
             request.setAttribute("userId", userId)
             true
         }.onFailure {
-            println(4444)
             logger.error { "refreshTokenCheck fail" }
         }.getOrThrow()
     }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/user/RefreshTokenUserUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/user/RefreshTokenUserUseCase.kt
@@ -1,0 +1,14 @@
+package wisoft.io.quotation.application.port.`in`.user
+
+interface RefreshTokenUserUseCase {
+    fun refreshToken(userId: String): UserTokenDto
+
+    data class RefreshTokenUserResponse(
+        val data: UserTokenDto,
+    )
+
+    data class UserTokenDto(
+        val accessToken: String,
+        val refreshToken: String,
+    )
+}

--- a/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
@@ -28,6 +28,7 @@ class UserService(
     val deleteUserPort: DeleteUserPort,
 ) : CreateUserUseCase,
     SignInUseCase,
+    RefreshTokenUserUseCase,
     DeleteUserUseCase,
     GetUserMyPageUseCase,
     GetUserPageUseCase,
@@ -98,6 +99,16 @@ class UserService(
             SignInUseCase.UserTokenDto(JWTUtil.generateAccessToken(user), JWTUtil.generateRefreshToken(user))
         }.onFailure {
             logger.error { "signIn fail: param[$request]" }
+        }.getOrThrow()
+    }
+
+    override fun refreshToken(userId: String): RefreshTokenUserUseCase.UserTokenDto {
+        return runCatching {
+            val user = getUserPort.getUserById(userId) ?: throw UserNotFoundException(userId)
+
+            RefreshTokenUserUseCase.UserTokenDto(JWTUtil.generateAccessToken(user), JWTUtil.generateRefreshToken(user))
+        }.onFailure {
+            logger.error { "refreshToken fail: param[id: $userId]" }
         }.getOrThrow()
     }
 

--- a/src/main/kotlin/wisoft/io/quotation/util/annotation/RefreshTokenAuthenticated.kt
+++ b/src/main/kotlin/wisoft/io/quotation/util/annotation/RefreshTokenAuthenticated.kt
@@ -1,0 +1,3 @@
+package wisoft.io.quotation.util.annotation
+
+annotation class RefreshTokenAuthenticated()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,7 +36,7 @@ environment:
     secret-key: "8kTcEnj4ABscsjcWVOg06brYjyOwwVwdMB7s1BGwzBQDhmASi"
     # 토큰 만료 시간 (1시간)
     access-token-expiration-time: 3600000
-    # 토큰 만료 시간 (1주일)
-    refresh-token-expiration-time: 604800000
+    # 토큰 만료 시간 (30일)
+    refresh-token-expiration-time: 2592000000
     # 토큰 만료 시간 (5분)
     password-refresh-token-expiration-time: 300000

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -126,7 +126,31 @@ class UserControllerTest(
                 userIdByRefreshToken shouldBe existUser.id
             }
         }
+        context("RefreshToken Test") {
+            test("RefreshToken 성공") {
+                // given
+                val existUser = repository.save(getUserEntityFixture())
+                val refreshToken = JWTUtil.generateRefreshToken(existUser.toDomain())
 
+                // when
+                val result =
+                    mockMvc.perform(
+                        MockMvcRequestBuilders.post("/users/refresh-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("Authorization", "Bearer $refreshToken"),
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                        .andReturn()
+                        .response.contentAsString
+
+                // then
+                val actual = objectMapper.readValue(result, SignInUseCase.SignInResponse::class.java)
+
+                val userIdByAccessToken = JWTUtil.extractUserIdByToken(actual.data.accessToken)
+                val userIdByRefreshToken = JWTUtil.extractUserIdByToken(actual.data.refreshToken)
+                userIdByAccessToken shouldBe existUser.id
+                userIdByRefreshToken shouldBe existUser.id
+            }
+        }
         context("deleteUser Test") {
             test("deleteUser 성공") {
                 // given


### PR DESCRIPTION
refreshToken API 추가와, RefershToken 만료기간을 30일로 설정

<!--아래 양식에 따라 작성하되 불필요한 항목은 삭제하고, 필요한 항목은 추가한다.-->

# 요구사항 및 기능 요약


# 관련 자료
- 설계 자료 - [노션 링크](https://www.notion.so/RefreshToken-API-96b48511057c4907be3b7951a74675a7?pvs=4)

# 작업 종류
<!--이 PR에서 작업한 항목을 모두 체크
되도록 한 PR에서는 하나의 작업을 체크하도록 구성-->
- [x] 기능 추가
- [x] 기능 변경
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# 코드 리뷰 시 참고 사항
<!--리뷰어가 빠르게 코드 리뷰를 할 수 있도록 설명
예) abc.kt의 L10-50은 코드 포맷 변경이므로 리뷰 필요 없음-->

# 테스트 정도
- [ ] 유닛 테스트
- [x] 통합 테스트
- [ ] 배포 테스트
