### PR TITLE
[TKT-126] fix: 명언 rank API 수정

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/QuotationController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/QuotationController.kt
@@ -8,6 +8,7 @@ import wisoft.io.quotation.application.port.`in`.quotation.GetQuotationRankUseCa
 import wisoft.io.quotation.application.port.`in`.quotation.GetQuotationUseCase
 import wisoft.io.quotation.domain.Paging
 import wisoft.io.quotation.domain.QuotationSortTarget
+import wisoft.io.quotation.domain.RankProperty
 import wisoft.io.quotation.domain.SortDirection
 import java.util.UUID
 
@@ -21,10 +22,21 @@ class QuotationController(
     @GetMapping("/rank")
     fun getQuotationRank(
         @RequestParam ids: List<UUID>?,
+        @RequestParam rankProperty: RankProperty,
+        @ModelAttribute paging: Paging?,
     ): ResponseEntity<GetQuotationRankUseCase.GetQuotationRankResponse> {
         return ResponseEntity.status(HttpStatus.OK).body(
             GetQuotationRankUseCase.GetQuotationRankResponse(
-                data = GetQuotationRankUseCase.Data(getQuotationLankUseCase.getQuotationRank(ids)),
+                data =
+                    GetQuotationRankUseCase.Data(
+                        getQuotationLankUseCase.getQuotationRank(
+                            GetQuotationRankUseCase.GetQuotationRankRequest(
+                                ids = ids,
+                                rankProperty = rankProperty,
+                                paging = paging,
+                            ),
+                        ),
+                    ),
             ),
         )
     }

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/QuotationAdaptor.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/QuotationAdaptor.kt
@@ -6,6 +6,7 @@ import wisoft.io.quotation.adaptor.out.persistence.entity.view.QuotationRankView
 import wisoft.io.quotation.adaptor.out.persistence.repository.QuotationCustomRepository
 import wisoft.io.quotation.adaptor.out.persistence.repository.QuotationRepository
 import wisoft.io.quotation.application.port.`in`.quotation.GetQuotationListUseCase
+import wisoft.io.quotation.application.port.`in`.quotation.GetQuotationRankUseCase
 import wisoft.io.quotation.application.port.out.quotation.GetQuotationListPort
 import wisoft.io.quotation.application.port.out.quotation.GetQuotationPort
 import wisoft.io.quotation.domain.Quotation
@@ -26,7 +27,7 @@ class QuotationAdaptor(
         return result.map { it.toDomain() }
     }
 
-    override fun getQuotationLank(ids: List<UUID>?): List<QuotationRankView> {
-        return quotationCustomRepository.findQuotationRank(ids)
+    override fun getQuotationLank(request: GetQuotationRankUseCase.GetQuotationRankRequest): List<QuotationRankView> {
+        return quotationCustomRepository.findQuotationRank(request)
     }
 }

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/entity/view/QuotationRankView.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/out/persistence/entity/view/QuotationRankView.kt
@@ -4,6 +4,7 @@ import java.util.*
 
 data class QuotationRankView(
     val id: UUID,
-    val likeRank: Long,
-    val shareRank: Long,
+    val rank: Long,
+    val count: Long,
+    val backgroundImagePath: String,
 )

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/quotation/GetQuotationRankUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/quotation/GetQuotationRankUseCase.kt
@@ -1,10 +1,18 @@
 package wisoft.io.quotation.application.port.`in`.quotation
 
 import wisoft.io.quotation.adaptor.out.persistence.entity.view.QuotationRankView
+import wisoft.io.quotation.domain.Paging
+import wisoft.io.quotation.domain.RankProperty
 import java.util.UUID
 
 interface GetQuotationRankUseCase {
-    fun getQuotationRank(ids: List<UUID>?): List<QuotationRankView>
+    fun getQuotationRank(request: GetQuotationRankRequest): List<QuotationRankView>
+
+    data class GetQuotationRankRequest(
+        val ids: List<UUID>?,
+        val rankProperty: RankProperty,
+        val paging: Paging?,
+    )
 
     data class GetQuotationRankResponse(
         val data: Data,

--- a/src/main/kotlin/wisoft/io/quotation/application/port/out/quotation/GetQuotationListPort.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/out/quotation/GetQuotationListPort.kt
@@ -2,11 +2,11 @@ package wisoft.io.quotation.application.port.out.quotation
 
 import wisoft.io.quotation.adaptor.out.persistence.entity.view.QuotationRankView
 import wisoft.io.quotation.application.port.`in`.quotation.GetQuotationListUseCase
+import wisoft.io.quotation.application.port.`in`.quotation.GetQuotationRankUseCase
 import wisoft.io.quotation.domain.Quotation
-import java.util.UUID
 
 interface GetQuotationListPort {
     fun getQuotationList(request: GetQuotationListUseCase.GetQuotationListRequest): List<Quotation>
 
-    fun getQuotationLank(ids: List<UUID>?): List<QuotationRankView>
+    fun getQuotationLank(request: GetQuotationRankUseCase.GetQuotationRankRequest): List<QuotationRankView>
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/service/QuotationService.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/service/QuotationService.kt
@@ -29,8 +29,8 @@ class QuotationService(
         }.getOrThrow()
     }
 
-    override fun getQuotationRank(ids: List<UUID>?): List<QuotationRankView> {
-        return getQuotationsPort.getQuotationLank(ids)
+    override fun getQuotationRank(request: GetQuotationRankUseCase.GetQuotationRankRequest): List<QuotationRankView> {
+        return getQuotationsPort.getQuotationLank(request)
     }
 
     override fun getQuotation(id: UUID): Quotation {

--- a/src/main/kotlin/wisoft/io/quotation/domain/Quotation.kt
+++ b/src/main/kotlin/wisoft/io/quotation/domain/Quotation.kt
@@ -29,5 +29,3 @@ data class Quotation(
     val createdTime: Timestamp,
     val lastModifiedTime: Timestamp? = null,
 )
-
-// like, share, comment 에 대한 순위 제공

--- a/src/main/kotlin/wisoft/io/quotation/domain/RankProperty.kt
+++ b/src/main/kotlin/wisoft/io/quotation/domain/RankProperty.kt
@@ -1,0 +1,6 @@
+package wisoft.io.quotation.domain
+
+enum class RankProperty {
+    LIKE,
+    SHARE,
+}


### PR DESCRIPTION
# 요구사항 및 기능 요약
### Description
* 명언 rank 제공 API 에 어떤 속성으로 rank 조회할지, paging 가능하도록 request 수정
* response에요청한 속성에 대해 imagePath, count, rank 제공하도록 수정

# 작업 종류
<!--이 PR에서 작업한 항목을 모두 체크
되도록 한 PR에서는 하나의 작업을 체크하도록 구성-->
- [ ] 기능 추가
- [x] 기능 변경
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# 테스트 정도
- [ ] 유닛 테스트
- [x] 통합 테스트
- [ ] 배포 테스트
