### PR TITLE
[TKT-140] fix: 목록 응답 객체 한번더 감싸는 부분 제외

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/BookmarkController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/BookmarkController.kt
@@ -49,9 +49,7 @@ class BookmarkController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
-                GetBookmarkListUseCase.GetBookmarkListResponse(
-                    GetBookmarkListUseCase.Data(bookmarks = result),
-                ),
+                GetBookmarkListUseCase.GetBookmarkListResponse(data = result),
             )
     }
 

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/CommentController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/CommentController.kt
@@ -40,7 +40,7 @@ class CommentController(
             .status(HttpStatus.OK)
             .body(
                 GetCommentListUseCase.GetCommentListResponse(
-                    GetCommentListUseCase.Data(result),
+                    data = result,
                 ),
             )
     }

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/NotificationController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/NotificationController.kt
@@ -22,10 +22,7 @@ class NotificationController(
             .status(HttpStatus.OK)
             .body(
                 GetNotificationListUseCase.GetNotificationListResponse(
-                    data =
-                        GetNotificationListUseCase.Data(
-                            notificationList = getNotificationListUseCase.getNotificationList(userId),
-                        ),
+                    data = getNotificationListUseCase.getNotificationList(userId),
                 ),
             )
     }

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/QuotationController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/QuotationController.kt
@@ -59,8 +59,9 @@ class QuotationController(
                     ids = ids,
                 ),
             )
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(GetQuotationListUseCase.GetQuotationListResponse(data = GetQuotationListUseCase.Data(quotationList = response)))
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(GetQuotationListUseCase.GetQuotationListResponse(data = response))
     }
 
     @GetMapping("/{id}")

--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
@@ -61,7 +61,7 @@ class UserController(
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(
-                GetUserListUseCase.GetUserListResponse(data = GetUserListUseCase.Data(users = response)),
+                GetUserListUseCase.GetUserListResponse(data = response),
             )
     }
 

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/bookmark/GetBookmarkListUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/bookmark/GetBookmarkListUseCase.kt
@@ -12,10 +12,6 @@ interface GetBookmarkListUseCase {
     )
 
     data class GetBookmarkListResponse(
-        val data: Data,
-    )
-
-    data class Data(
-        val bookmarks: List<Bookmark>,
+        val data: List<Bookmark>,
     )
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/comment/GetCommentListUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/comment/GetCommentListUseCase.kt
@@ -14,10 +14,6 @@ interface GetCommentListUseCase {
     )
 
     data class GetCommentListResponse(
-        val data: Data,
-    )
-
-    data class Data(
-        val commentList: List<Comment>,
+        val data: List<Comment>,
     )
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/notification/GetNotificationListUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/notification/GetNotificationListUseCase.kt
@@ -6,10 +6,6 @@ interface GetNotificationListUseCase {
     fun getNotificationList(userId: String): List<Notification>
 
     data class GetNotificationListResponse(
-        val data: Data,
-    )
-
-    data class Data(
-        val notificationList: List<Notification>,
+        val data: List<Notification>,
     )
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/quotation/GetQuotationListUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/quotation/GetQuotationListUseCase.kt
@@ -18,10 +18,6 @@ interface GetQuotationListUseCase {
     )
 
     data class GetQuotationListResponse(
-        val data: Data,
-    )
-
-    data class Data(
-        val quotationList: List<Quotation>,
+        val data: List<Quotation>,
     )
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/user/GetUserListUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/user/GetUserListUseCase.kt
@@ -10,11 +10,7 @@ interface GetUserListUseCase {
     )
 
     data class GetUserListResponse(
-        val data: Data,
-    )
-
-    data class Data(
-        val users: List<UserDto>,
+        val data: List<UserDto>,
     )
 
     data class UserDto(

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/BookmarkControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/BookmarkControllerTest.kt
@@ -132,7 +132,7 @@ class BookmarkControllerTest(
                     objectMapper.readValue(
                         result,
                         GetBookmarkListUseCase.GetBookmarkListResponse::class.java,
-                    ).data.bookmarks.first()
+                    ).data.first()
 
                 actual.id shouldBe bookmark.id
                 actual.name shouldBe bookmark.name

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/CommentControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/CommentControllerTest.kt
@@ -263,7 +263,7 @@ class CommentControllerTest(
                     objectMapper.readValue(
                         result,
                         GetCommentListUseCase.GetCommentListResponse::class.java,
-                    ).data.commentList.first()
+                    ).data.first()
 
                 // then
                 actual.id shouldBe comment.id
@@ -294,7 +294,7 @@ class CommentControllerTest(
                     objectMapper.readValue(
                         result,
                         GetCommentListUseCase.GetCommentListResponse::class.java,
-                    ).data.commentList.first()
+                    ).data.first()
 
                 // then
                 actual.id shouldBe comment.id
@@ -325,7 +325,7 @@ class CommentControllerTest(
                     objectMapper.readValue(
                         result,
                         GetCommentListUseCase.GetCommentListResponse::class.java,
-                    ).data.commentList.first()
+                    ).data.first()
 
                 // then
                 actual.id shouldBe childComment.id

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/NotificationControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/NotificationControllerTest.kt
@@ -76,7 +76,7 @@ class NotificationControllerTest(
                     objectMapper.readValue(
                         result,
                         GetNotificationListUseCase.GetNotificationListResponse::class.java,
-                    ).data.notificationList.first()
+                    ).data.first()
 
                 // then
                 actual.commenterId shouldBe user.id

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/QuotationControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/QuotationControllerTest.kt
@@ -164,7 +164,7 @@ class QuotationControllerTest(
                     objectMapper.readValue(
                         result,
                         GetQuotationListUseCase.GetQuotationListResponse::class.java,
-                    ).data.quotationList.first()
+                    ).data.first()
 
                 actual.id shouldBe quotation.id
                 actual.author.id shouldBe author.id

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -344,7 +344,7 @@ class UserControllerTest(
 
                 // then
                 val actual = objectMapper.readValue(result, GetUserListUseCase.GetUserListResponse::class.java)
-                val actualUserDto = actual.data.users[0]
+                val actualUserDto = actual.data.first()
 
                 actualUserDto.id shouldBe existUser.id
                 actualUserDto.nickname shouldBe existUser.nickname
@@ -371,7 +371,7 @@ class UserControllerTest(
 
                 // then
                 val actual = objectMapper.readValue(result, GetUserListUseCase.GetUserListResponse::class.java)
-                val actualUserDto = actual.data.users[0]
+                val actualUserDto = actual.data.first()
 
                 actualUserDto.id shouldBe existUser.id
                 actualUserDto.nickname shouldBe existUser.nickname
@@ -398,7 +398,7 @@ class UserControllerTest(
 
                 // then
                 val actual = objectMapper.readValue(result, GetUserListUseCase.GetUserListResponse::class.java)
-                val actualUserDto = actual.data.users[0]
+                val actualUserDto = actual.data.first()
 
                 actualUserDto.id shouldBe existUser.id
                 actualUserDto.nickname shouldBe existUser.nickname


### PR DESCRIPTION
<!--아래 양식에 따라 작성하되 불필요한 항목은 삭제하고, 필요한 항목은 추가한다.-->

# 요구사항 및 기능 요약
* 목록조회 시 response에 한번더 data로 감싸는 부분 제외 => 모두 data 한단계로 감싸도록 변경 (프론트 편의성 향상)
* 해당 이슈 수행하면서 swagger 에서 객체 두번감싸있는 경우 응답 깨지는 현상도 해결

# 관련 자료
- 설계 자료 - [노션 링크]()

# 작업 종류
<!--이 PR에서 작업한 항목을 모두 체크
되도록 한 PR에서는 하나의 작업을 체크하도록 구성-->
- [ ] 기능 추가
- [x] 기능 변경
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# 코드 리뷰 시 참고 사항
<!--리뷰어가 빠르게 코드 리뷰를 할 수 있도록 설명
예) abc.kt의 L10-50은 코드 포맷 변경이므로 리뷰 필요 없음-->

# 테스트 정도
- [ ] 유닛 테스트
- [x] 통합 테스트
- [ ] 배포 테스트
