### PR TITLE
#104/feat/user quotation alarm time

### DIFF
--- a/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
+++ b/src/main/kotlin/wisoft/io/quotation/adaptor/in/http/UserController.kt
@@ -30,6 +30,9 @@ class UserController(
     val updateUserUseCase: UpdateUserUseCase,
     val validateUserUesCase: ValidateUserUesCase,
     val resetPasswordUserUseCase: ResetPasswordUserUseCase,
+    val createQuotationAlarmTimeUseCase: CreateQuotationAlarmTimeUseCase,
+    val getQuotationAlarmTimeUseCase: GetQuotationAlarmTimeUseCase,
+    val patchQuotationAlarmTimeUseCase: PatchQuotationAlarmTimeUseCase,
 ) {
     @PostMapping("/users")
     fun createUser(
@@ -180,5 +183,56 @@ class UserController(
     ): ResponseEntity<DeleteUserUseCase> {
         deleteUserUseCase.deleteUser(id)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+
+    @PostMapping("/users/{userId}/quotation-alarm-time")
+    @LoginAuthenticated
+    fun createQuotationAlarmTimes(
+        @PathVariable("userId") userId: String,
+        @RequestBody @Valid request: CreateQuotationAlarmTimeUseCase.CreateQuotationAlarmTimeRequest,
+    ): ResponseEntity<CreateQuotationAlarmTimeUseCase.CreateQuotationAlarmTimeResponse> {
+        val response = createQuotationAlarmTimeUseCase.createQuotationAlarmTime(userId, request)
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED).body(
+                CreateQuotationAlarmTimeUseCase.CreateQuotationAlarmTimeResponse(
+                    data = CreateQuotationAlarmTimeUseCase.Data(response),
+                ),
+            )
+    }
+
+    @GetMapping("/users/{userId}/quotation-alarm-time")
+    @LoginAuthenticated
+    fun getQuotationAlarmTimes(
+        @PathVariable("userId") userId: String,
+    ): ResponseEntity<GetQuotationAlarmTimeUseCase.GetQuotationAlarmTimeResponse> {
+        val response = getQuotationAlarmTimeUseCase.getQuotationAlarmTime(userId)
+
+        return ResponseEntity
+            .status(HttpStatus.OK).body(
+                GetQuotationAlarmTimeUseCase.GetQuotationAlarmTimeResponse(
+                    data =
+                        GetQuotationAlarmTimeUseCase.Data(
+                            quotationAlarmTimes = response,
+                        ),
+                ),
+            )
+    }
+
+    // FIXME: Id를 이용한 삭제가 불가능해서, Body의 값에 따라서 처리하도록 변경
+    @PatchMapping("/users/{userId}/quotation-alarm-time")
+    @LoginAuthenticated
+    fun deleteQuotationAlarmTimes(
+        @PathVariable("userId") userId: String,
+        @RequestBody @Valid request: PatchQuotationAlarmTimeUseCase.PatchQuotationAlarmTimeRequest,
+    ): ResponseEntity<PatchQuotationAlarmTimeUseCase.PatchQuotationAlarmTimeResponse> {
+        val response = patchQuotationAlarmTimeUseCase.patchQuotationAlarmTime(userId, request)
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED).body(
+                PatchQuotationAlarmTimeUseCase.PatchQuotationAlarmTimeResponse(
+                    data = PatchQuotationAlarmTimeUseCase.Data(response),
+                ),
+            )
     }
 }

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/user/CreateQuotationAlarmTimeUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/user/CreateQuotationAlarmTimeUseCase.kt
@@ -1,0 +1,22 @@
+package wisoft.io.quotation.application.port.`in`.user
+
+import java.sql.Timestamp
+
+interface CreateQuotationAlarmTimeUseCase {
+    fun createQuotationAlarmTime(
+        userId: String,
+        request: CreateQuotationAlarmTimeRequest,
+    ): String
+
+    data class CreateQuotationAlarmTimeRequest(
+        val quotationAlarmTime: Timestamp,
+    )
+
+    data class CreateQuotationAlarmTimeResponse(
+        val data: Data,
+    )
+
+    data class Data(
+        val id: String,
+    )
+}

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/user/CreateQuotationAlarmTimeUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/user/CreateQuotationAlarmTimeUseCase.kt
@@ -1,7 +1,5 @@
 package wisoft.io.quotation.application.port.`in`.user
 
-import java.sql.Timestamp
-
 interface CreateQuotationAlarmTimeUseCase {
     fun createQuotationAlarmTime(
         userId: String,
@@ -9,7 +7,8 @@ interface CreateQuotationAlarmTimeUseCase {
     ): String
 
     data class CreateQuotationAlarmTimeRequest(
-        val quotationAlarmTime: Timestamp,
+        val quotationAlarmHour: Int,
+        val quotationAlarmMinute: Int,
     )
 
     data class CreateQuotationAlarmTimeResponse(

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/user/GetQuotationAlarmTimeUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/user/GetQuotationAlarmTimeUseCase.kt
@@ -1,0 +1,15 @@
+package wisoft.io.quotation.application.port.`in`.user
+
+import java.sql.Timestamp
+
+interface GetQuotationAlarmTimeUseCase {
+    fun getQuotationAlarmTime(userId: String): List<Timestamp>
+
+    data class GetQuotationAlarmTimeResponse(
+        val data: Data,
+    )
+
+    data class Data(
+        val quotationAlarmTimes: List<Timestamp>,
+    )
+}

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/user/PatchQuotationAlarmTimeUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/user/PatchQuotationAlarmTimeUseCase.kt
@@ -1,0 +1,22 @@
+package wisoft.io.quotation.application.port.`in`.user
+
+import java.sql.Timestamp
+
+interface PatchQuotationAlarmTimeUseCase {
+    fun patchQuotationAlarmTime(
+        userId: String,
+        request: PatchQuotationAlarmTimeRequest,
+    ): String
+
+    data class PatchQuotationAlarmTimeRequest(
+        val quotationAlarmTime: Timestamp,
+    )
+
+    data class PatchQuotationAlarmTimeResponse(
+        val data: Data,
+    )
+
+    data class Data(
+        val id: String,
+    )
+}

--- a/src/main/kotlin/wisoft/io/quotation/application/port/in/user/PatchQuotationAlarmTimeUseCase.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/port/in/user/PatchQuotationAlarmTimeUseCase.kt
@@ -1,7 +1,5 @@
 package wisoft.io.quotation.application.port.`in`.user
 
-import java.sql.Timestamp
-
 interface PatchQuotationAlarmTimeUseCase {
     fun patchQuotationAlarmTime(
         userId: String,
@@ -9,7 +7,8 @@ interface PatchQuotationAlarmTimeUseCase {
     ): String
 
     data class PatchQuotationAlarmTimeRequest(
-        val quotationAlarmTime: Timestamp,
+        val quotationAlarmHour: Int,
+        val quotationAlarmMinute: Int,
     )
 
     data class PatchQuotationAlarmTimeResponse(

--- a/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
@@ -13,6 +13,9 @@ import wisoft.io.quotation.util.JWTUtil
 import wisoft.io.quotation.util.SaltUtil
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 @Transactional(readOnly = true)
@@ -221,7 +224,8 @@ class UserService(
         return runCatching {
             val user = getUserPort.getUserById(userId) ?: throw UserNotFoundException("id: $userId")
 
-            val newAlarmTime = request.quotationAlarmTime.toLocalDateTime()
+            val localTime = LocalTime.of(request.quotationAlarmHour, request.quotationAlarmMinute)
+            val newAlarmTime = LocalDateTime.of(LocalDate.now(), localTime)
             val updatedTimes = user.quotationAlarmTimes.toMutableList()
 
             val existingTime =
@@ -231,9 +235,9 @@ class UserService(
                 }
 
             if (existingTime != null) {
-                throw QuotationAlarmTimeDuplicateException("timestamp: ${request.quotationAlarmTime}")
+                throw QuotationAlarmTimeDuplicateException("hour: ${request.quotationAlarmHour}, minute: ${request.quotationAlarmMinute}")
             } else {
-                updatedTimes.add(request.quotationAlarmTime)
+                updatedTimes.add(Timestamp.valueOf(newAlarmTime))
             }
 
             // 사용자 정보 업데이트
@@ -254,7 +258,8 @@ class UserService(
         return runCatching {
             val user = getUserPort.getUserById(userId) ?: throw UserNotFoundException("id: $userId")
 
-            val newAlarmTime = request.quotationAlarmTime.toLocalDateTime()
+            val localTime = LocalTime.of(request.quotationAlarmHour, request.quotationAlarmMinute)
+            val newAlarmTime = LocalDateTime.of(LocalDate.now(), localTime)
             val updatedTimes = user.quotationAlarmTimes.toMutableList()
 
             val existingTime =
@@ -266,7 +271,7 @@ class UserService(
             if (existingTime != null) {
                 updatedTimes.remove(existingTime)
             } else {
-                throw QuotationAlarmTimeNotFoundException("timestamp: ${request.quotationAlarmTime}")
+                throw QuotationAlarmTimeNotFoundException("hour: ${request.quotationAlarmHour}, minute: ${request.quotationAlarmMinute}")
             }
 
             // 사용자 정보 업데이트

--- a/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
+++ b/src/main/kotlin/wisoft/io/quotation/application/service/UserService.kt
@@ -8,11 +8,7 @@ import wisoft.io.quotation.application.port.out.*
 import wisoft.io.quotation.application.port.out.bookmark.GetBookmarkListPort
 import wisoft.io.quotation.application.port.out.user.*
 import wisoft.io.quotation.domain.User
-import wisoft.io.quotation.exception.error.InvalidRequestParameterException
-import wisoft.io.quotation.exception.error.InvalidUserException
-import wisoft.io.quotation.exception.error.UserDuplicateException
-import wisoft.io.quotation.exception.error.UserNotFoundException
-import wisoft.io.quotation.exception.error.http.BadRequestException
+import wisoft.io.quotation.exception.error.*
 import wisoft.io.quotation.util.JWTUtil
 import wisoft.io.quotation.util.SaltUtil
 import java.sql.Timestamp
@@ -235,7 +231,7 @@ class UserService(
                 }
 
             if (existingTime != null) {
-                throw BadRequestException("Time Duplication Exception")
+                throw QuotationAlarmTimeDuplicateException("timestamp: ${request.quotationAlarmTime}")
             } else {
                 updatedTimes.add(request.quotationAlarmTime)
             }
@@ -270,7 +266,7 @@ class UserService(
             if (existingTime != null) {
                 updatedTimes.remove(existingTime)
             } else {
-                throw BadRequestException("Time Not Found Exception")
+                throw QuotationAlarmTimeNotFoundException("timestamp: ${request.quotationAlarmTime}")
             }
 
             // 사용자 정보 업데이트

--- a/src/main/kotlin/wisoft/io/quotation/domain/User.kt
+++ b/src/main/kotlin/wisoft/io/quotation/domain/User.kt
@@ -69,4 +69,10 @@ data class User(
             identityVerificationAnswer = dto.identityVerificationAnswer ?: this.identityVerificationAnswer,
         )
     }
+
+    fun updateQuotationAlarmTimes(updatedQuotationAlarmTimes: List<Timestamp>): User {
+        return this.copy(
+            quotationAlarmTimes = updatedQuotationAlarmTimes,
+        )
+    }
 }

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/QuotationAlarmTimeDuplicateException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/QuotationAlarmTimeDuplicateException.kt
@@ -1,0 +1,5 @@
+package wisoft.io.quotation.exception.error
+
+import wisoft.io.quotation.exception.error.http.DuplicateException
+
+class QuotationAlarmTimeDuplicateException(override val value: String) : DuplicateException(value = value)

--- a/src/main/kotlin/wisoft/io/quotation/exception/error/QuotationAlarmTimeNotFoundException.kt
+++ b/src/main/kotlin/wisoft/io/quotation/exception/error/QuotationAlarmTimeNotFoundException.kt
@@ -1,0 +1,5 @@
+package wisoft.io.quotation.exception.error
+
+import wisoft.io.quotation.exception.error.http.NotFoundException
+
+class QuotationAlarmTimeNotFoundException(override val value: String) : NotFoundException(value = value)

--- a/src/test/kotlin/wisoft/io/quotation/fixture/entity/UserEntityFixture.kt
+++ b/src/test/kotlin/wisoft/io/quotation/fixture/entity/UserEntityFixture.kt
@@ -20,3 +20,20 @@ fun getUserEntityFixture(
         createdTime = Timestamp.valueOf(LocalDateTime.now()),
     )
 }
+
+fun getUserEntityFixtureIncludeQuotationAlarmTimes(
+    id: String? = null,
+    nickname: String? = null,
+): UserEntity {
+    return UserEntity(
+        id = id ?: "testUser",
+        nickname = nickname ?: "testNickname",
+        password = BCrypt.hashpw("password", BCrypt.gensalt()),
+        identityVerificationQuestion = "question",
+        identityVerificationAnswer = "answer",
+        commentAlarm = false,
+        quotationAlarm = true,
+        createdTime = Timestamp.valueOf(LocalDateTime.now()),
+        quotationAlarmTimes = listOf(Timestamp.valueOf(LocalDateTime.now().withSecond(0).withNano(0))),
+    )
+}

--- a/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
+++ b/src/test/kotlin/wisoft/io/quotation/integration/http/adaptor/in/UserControllerTest.kt
@@ -23,7 +23,7 @@ import wisoft.io.quotation.fixture.entity.getUserEntityFixture
 import wisoft.io.quotation.fixture.entity.getUserEntityFixtureIncludeQuotationAlarmTimes
 import wisoft.io.quotation.util.JWTUtil
 import java.sql.Timestamp
-import java.time.LocalDateTime
+import java.time.LocalTime
 
 @SpringBootTest
 @ContextConfiguration(classes = [DatabaseContainerConfig::class])
@@ -592,9 +592,11 @@ class UserControllerTest(
                 // given
                 val existUser = repository.save(getUserEntityFixture())
                 val accessToken = JWTUtil.generateAccessToken(userMapper.toDomain(existUser))
+                val localTime = LocalTime.now()
                 val request =
                     CreateQuotationAlarmTimeUseCase.CreateQuotationAlarmTimeRequest(
-                        quotationAlarmTime = Timestamp.valueOf(LocalDateTime.now()),
+                        quotationAlarmHour = localTime.hour,
+                        quotationAlarmMinute = localTime.minute,
                     )
 
                 // when
@@ -623,9 +625,13 @@ class UserControllerTest(
                 val accessToken = JWTUtil.generateAccessToken(userMapper.toDomain(existUser))
                 val expectedStatus = HttpMessage.HTTP_400.status
                 val expectedPath = "/users/${existUser.id}/quotation-alarm-time"
+                val localDateTime = existUser.quotationAlarmTimes.first().toLocalDateTime()
+                val localTime = localDateTime.toLocalTime()
+
                 val request =
                     CreateQuotationAlarmTimeUseCase.CreateQuotationAlarmTimeRequest(
-                        quotationAlarmTime = Timestamp.valueOf(LocalDateTime.now()),
+                        quotationAlarmHour = localTime.hour,
+                        quotationAlarmMinute = localTime.minute,
                     )
 
                 // when
@@ -678,9 +684,13 @@ class UserControllerTest(
                 val existUser = repository.save(getUserEntityFixtureIncludeQuotationAlarmTimes())
                 val accessToken = JWTUtil.generateAccessToken(userMapper.toDomain(existUser))
 
+                val timestamp = existUser.quotationAlarmTimes.first()
+                val requestLocalTime = timestamp.toLocalDateTime().toLocalTime()
+
                 val request =
                     PatchQuotationAlarmTimeUseCase.PatchQuotationAlarmTimeRequest(
-                        quotationAlarmTime = existUser.quotationAlarmTimes.first(),
+                        quotationAlarmHour = requestLocalTime.hour,
+                        quotationAlarmMinute = requestLocalTime.minute,
                     )
                 val validateUserRequestJson = objectMapper.writeValueAsString(request)
 
@@ -711,10 +721,12 @@ class UserControllerTest(
                 val expectedPath = "/users/${existUser.id}/quotation-alarm-time"
                 val existTime = existUser.quotationAlarmTimes.first()
                 val updatedTime = Timestamp.valueOf(existTime.toLocalDateTime().plusHours(1))
+                val requestLocalTime = updatedTime.toLocalDateTime().toLocalTime()
 
                 val request =
                     PatchQuotationAlarmTimeUseCase.PatchQuotationAlarmTimeRequest(
-                        quotationAlarmTime = updatedTime,
+                        quotationAlarmHour = requestLocalTime.hour,
+                        quotationAlarmMinute = requestLocalTime.minute,
                     )
                 val validateUserRequestJson = objectMapper.writeValueAsString(request)
 


### PR DESCRIPTION
<!--아래 양식에 따라 작성하되 불필요한 항목은 삭제하고, 필요한 항목은 추가한다.-->

# 요구사항 및 기능 요약
User QuotationAlarmTimes API를 구현함 CRD만 구현함.

# 관련 자료
- 설계 자료 - [노션 링크](https://www.notion.so/Backend-User-QuotationAlarmTimes-API-7845908f99cd4799b17ffa3450d313b3?pvs=4)

# 작업 종류
<!--이 PR에서 작업한 항목을 모두 체크
되도록 한 PR에서는 하나의 작업을 체크하도록 구성-->
- [x] 기능 추가

# 코드 리뷰 시 참고 사항
<!--리뷰어가 빠르게 코드 리뷰를 할 수 있도록 설명
예) abc.kt의 L10-50은 코드 포맷 변경이므로 리뷰 필요 없음-->
### Quotaiton Delelte API
ID가 따로 나와있지 않아서, Delete Method를 사용할 수 없었고, Patch Method의 Body에 시간을 넣고, 존재하면 삭제, 존재하지 않으면 NotFound 예외를 발생시킴.
따라서, 추후 개선작업에 QuotaitonAlarmTImes를 테이블로 분리하는게 좋아보임

### API 사용 관련
**시간과 분**이 같은 Timestamp가 존재하면, Create의 경우 중복으로 인해 생성할 수 없고, Patch의 경우 삭제됨.

더 좋은 방법에 대한 논의 환영 ^_^


# 테스트 정도
- [ ] 유닛 테스트
- [x] 통합 테스트
- [ ] 배포 테스트
